### PR TITLE
Add devicetypeid parameter and proper default to iOS-sim wrapper

### DIFF
--- a/cmake/core/sugar_add_ios_gtest.cmake
+++ b/cmake/core/sugar_add_ios_gtest.cmake
@@ -46,6 +46,8 @@ function(sugar_add_ios_gtest testname targetname)
       "${IOS_SIM}"
       "--target"
       "${targetname}"
+      "--devicetypeid"
+      "iPhone-5s"
       "--args"
       ${test_argv}
       "--configuration"

--- a/python/ios_simulator_launcher.py
+++ b/python/ios_simulator_launcher.py
@@ -52,6 +52,12 @@ parser.add_argument(
     help='print a lot info'
 )
 
+parser.add_argument(
+    '--devicetypeid',
+    type=str,
+    help='the type of the device simulator'
+)
+
 args = parser.parse_args()
 
 class Log:
@@ -111,7 +117,11 @@ def try_run_simulator(application):
       '--stderr',
       cerr_sim_log.name,
   ]
-
+  
+  if args.devicetypeid:
+    launch_command.append('--devicetypeid')
+    launch_command.append(args.devicetypeid)
+                          
   if args.args:
     launch_command.append('--args')
     for x in args.args:


### PR DESCRIPTION
Since 5.0, iOS-sim will not select iPhone by default, but the first simulator in the list, which unfortunately, will be Apple watch.